### PR TITLE
Add `Glicko2Estimator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+*.swo
 .venv
 *.egg-info/
 dist/*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's intended to provide a simple API for creating elo ratings in a small games 
 
 What problem does this package solve?
 
-Despite there being many ratings systems implementations available (e.g. [sublee/elo](https://github.com/sublee/elo/) [ddm7018/Elo](https://github.com/ddm7018/Elo), [rshk/elo](https://github.com/rshk/elo), [EloPy](https://github.com/HankSheehan/EloPy), [PythonSkills](https://github.com/McLeopold/PythonSkills), [pyglicko2](https://github.com/ryankirkman/pyglicko2), [glicko](https://github.com/sublee/glicko)) it's hard to find one that satisfies several criteria for ease of use:
+Despite there being many ratings systems implementations available (e.g. [sublee/elo](https://github.com/sublee/elo/) [ddm7018/Elo](https://github.com/ddm7018/Elo), [rshk/elo](https://github.com/rshk/elo), [EloPy](https://github.com/HankSheehan/EloPy), [PythonSkills](https://github.com/McLeopold/PythonSkills), [pyglicko2](https://github.com/ryankirkman/pyglicko2),[glicko2](https://github.com/deepy/glicko2), [glicko](https://github.com/sublee/glicko)) it's hard to find one that satisfies several criteria for ease of use:
   - A simple and clean API that's convenient for a data-driven model development loop, for which use case the scikit-learn estimator [interface](https://scikit-learn.org/stable/modules/classes.html) is the *de facto* standard for this use case
   - Explicit management of intervals of validity for ratings, such that as matches occur a timeseries of ratings is evolved for each players (i.e. type-2 data management as opposed to type-1 fire-and-forget ratings)
 
@@ -26,7 +26,7 @@ pip3 install skelo
 
 - [`EloEstimator`](https://github.com/mbhynes/skelo/blob/main/skelo/model/elo.py)
 - [`Glicko2Estimator`](https://github.com/mbhynes/skelo/blob/main/skelo/model/glicko2.py)
-  - This class is a light wrapper around [pyglicko2](https://github.com/ryankirkman/pyglicko2), which was chosen over [PythonSkills](https://github.com/McLeopold/PythonSkills) since it implements the Glicko2 algorithm rather than the original Glicko(1?) algorithm.
+  - This class is a light wrapper around [glicko2](https://github.com/deepy/glicko2), which was chosen over [PythonSkills](https://github.com/McLeopold/PythonSkills) since it implements the Glicko2 algorithm rather than the original Glicko algorithm.
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skelo
 
-An implementation of the [Elo](https://en.wikipedia.org/wiki/Elo_rating_system) and [Glicko2](https://en.wikipedia.org/wiki/Glicko_rating_system) with a [scikit-learn](https://scikit-learn.org/stable/)-compatible interface.
+An implementation of the [Elo](https://en.wikipedia.org/wiki/Elo_rating_system) and [Glicko2](https://en.wikipedia.org/wiki/Glicko_rating_system) rating systems with a [scikit-learn](https://scikit-learn.org/stable/)-compatible interface.
 
 The `skelo` package is a simple implementation suitable for small-scale ratings systems that fit into memory on a single machine.
 It's intended to provide a simple API for creating elo ratings in a small games on the scale thousands of players and millions of matches, primarily as a means of feature transformation for inclusion in other `sklearn` pipelines.
@@ -9,11 +9,11 @@ It's intended to provide a simple API for creating elo ratings in a small games 
 
 What problem does this package solve?
 
-Despite there being many ratings systems implementations available (e.g. [sublee/elo](https://github.com/sublee/elo/) [ddm7018/Elo](https://github.com/ddm7018/Elo), [rshk/elo](https://github.com/rshk/elo), [EloPy](https://github.com/HankSheehan/EloPy), [PythonSkills](https://github.com/McLeopold/PythonSkills), [pyglicko2](https://github.com/ryankirkman/pyglicko2),[glicko2](https://github.com/deepy/glicko2), [glicko](https://github.com/sublee/glicko)) it's hard to find one that satisfies several criteria for ease of use:
+Despite there being many ratings systems implementations available (e.g. [sublee/elo](https://github.com/sublee/elo/) [ddm7018/Elo](https://github.com/ddm7018/Elo), [rshk/elo](https://github.com/rshk/elo), [EloPy](https://github.com/HankSheehan/EloPy), [PythonSkills](https://github.com/McLeopold/PythonSkills), [pyglicko2](https://github.com/ryankirkman/pyglicko2), [glicko2](https://github.com/deepy/glicko2), [glicko](https://github.com/sublee/glicko)) it's hard to find one that satisfies several criteria:
   - A simple and clean API that's convenient for a data-driven model development loop, for which use case the scikit-learn estimator [interface](https://scikit-learn.org/stable/modules/classes.html) is the *de facto* standard for this use case
   - Explicit management of intervals of validity for ratings, such that as matches occur a timeseries of ratings is evolved for each players (i.e. type-2 data management as opposed to type-1 fire-and-forget ratings)
 
-This package addresses the criteria above by providing a simple interface for storing the 
+This package addresses the criteria above by providing a simple interface for in-memory data management (i.e. storing the ratings as they evolve and *resolving* a player to the respective rating at an arbitrary point in time) and scikit-learn classifier methods to interact with the ratings in a typical data science development cycle.
 
 ## Installation
 
@@ -22,11 +22,124 @@ This package addresses the criteria above by providing a simple interface for st
 pip3 install skelo
 ```
 
+## Quickstart
+
+As a quickstart, we can load and fit an `EloEsimator` (classifier) on some sample tennis data:
+```python
+import numpy as np
+import pandas as pd
+from skelo.model.elo import EloEstimator
+
+df = pd.read_csv("https://raw.githubusercontent.com/JeffSackmann/tennis_atp/master/atp_matches_1979.csv")
+
+model = EloEstimator(
+  key1_field="winner_name",
+  key2_field="loser_name",
+  timestamp_field="tourney_date",
+  initial_time=19781231,
+).fit(df, len(df) * [1])
+```
+
+- The ratings data is availble as a `pandas DataFrame` if we wish to do any further analysis on it:
+```python
+>>> model.rating_model.to_frame()
+
+                     key       rating  valid_from    valid_to
+0               Tim Vann  1500.000000    19781231  19790115.0
+1               Tim Vann  1490.350941    19790115         NaN
+2     Alejandro Gattiker  1500.000000    19781231  19790917.0
+3     Alejandro Gattiker  1492.529478    19790917  19791119.0
+4     Alejandro Gattiker  1485.415228    19791119         NaN
+...                  ...          ...         ...         ...
+8462       Tom Gullikson  1483.914545    19791029  19791105.0
+8463       Tom Gullikson  1478.934755    19791105  19791105.0
+8464       Tom Gullikson  1489.400521    19791105  19791105.0
+8465       Tom Gullikson  1498.757080    19791105  19791113.0
+8466       Tom Gullikson  1490.600009    19791113         NaN
+```
+
+- Once fit, we can transform a `DataFrame` or `ndarray` of player/player match data into the respective ratings for each player immediately *prior* to the match
+```
+>>> model.transform(df, output_type='rating')
+
+               r1           r2
+0     1598.787906  1530.008777
+1     1548.633423  1585.653196
+2     1548.633423  1598.787906
+3     1445.555739  1489.089241
+4     1439.595891  1502.254666
+...           ...          ...
+3954  1872.284295  1714.108269
+3955  1872.284295  1698.007094
+3956  1837.623245  1714.108269
+3957  1837.623245  1698.007094
+3958  1698.007094  1714.108269
+
+[3959 rows x 2 columns]
+```
+- Alternatively, we could also transform a datafrom into the forecast probabilities of victory for the player "winner_name":
+```
+>>> model.transform(df, output_type='prob')
+
+0       0.597708
+1       0.446925
+2       0.428319
+3       0.437676
+4       0.410792
+          ...
+3954    0.713110
+3955    0.731691
+3956    0.670624
+3957    0.690764
+3958    0.476845
+Length: 3959, dtype: float64
+```
+
+- These probabilities are also available using the `predict_proba` or `predict` classifier methods:
+```
+>>> model.predict_proba(df)
+
+           pr1       pr2
+0     0.597708  0.402292
+1     0.446925  0.553075
+2     0.428319  0.571681
+3     0.437676  0.562324
+4     0.410792  0.589208
+...        ...       ...
+3954  0.713110  0.286890
+3955  0.731691  0.268309
+3956  0.670624  0.329376
+3957  0.690764  0.309236
+3958  0.476845  0.523155
+
+[3959 rows x 2 columns]
+```
+
+```
+>>> model.predict(df)
+
+0       1.0
+1       0.0
+2       0.0
+3       0.0
+4       0.0
+       ...
+3954    1.0
+3955    1.0
+3956    1.0
+3957    1.0
+3958    0.0
+Name: pr1, Length: 3959, dtype: float64
+```
+
 ## Available Models
 
+The models in this package are the following:
+
 - [`EloEstimator`](https://github.com/mbhynes/skelo/blob/main/skelo/model/elo.py)
+  - This class is a pure python implementation of a standard [Elo rating system](https://en.wikipedia.org/wiki/Elo_rating_system), without draws or homefield advantage
 - [`Glicko2Estimator`](https://github.com/mbhynes/skelo/blob/main/skelo/model/glicko2.py)
-  - This class is a light wrapper around [glicko2](https://github.com/deepy/glicko2), which was chosen over [PythonSkills](https://github.com/McLeopold/PythonSkills) since it implements the Glicko2 algorithm rather than the original Glicko algorithm.
+  - This class implements the [Glicko2](https://en.wikipedia.org/wiki/Glicko_rating_system) rating system, implemented using a light wrapper around [glicko2](https://github.com/deepy/glicko2)
 
 ## Example Usage
 
@@ -236,7 +349,7 @@ rank_test_score                                             1                   
 
 ## Development Setup
 
-If you would like to contribute to this repository, please open an [issue](issues/new) first to document the extension or modification you're interested  in contributing.
+If you would like to contribute to this repository, please open an [issue](issues/new) first to document the extension or modification you're interested in contributing.
 
 ### `dev` scripts
 
@@ -263,4 +376,58 @@ The `dev` script (and other scripts in `bin`) contain convenience wrappers for s
   ./dev upload
   ```
 
-## Development Setup
+### Creating an `RatingEstimator`
+
+The available models extend the `skelo.model.RatingEstimator` [class](https://github.com/mbhynes/skelo/blob/main/skelo/model/__init__.py) which implements the `sklearn` wrapper interface around a `skelo.model.RatingModel` instance.
+
+To create a new classifier, it's necessary to:
+  - Extend the `RatingModel` to implement the rating update formulas through the methods:
+    - `evolve_rating(r1, r2, label)`, which computes a new rating given the players' previous ratings, `r1` and `r2`, prior to a match with outcome `label`
+    - `compute_prob(r1, r2)`, which computes the probability of victory of a player with rating `r1` over a player with rating `r2`
+
+```python
+class EloModel(RatingModel):
+  def __init__(self, default_k=20, k_fn=None, initial_value=1500, initial_time=0, **kwargs):
+    super().__init__(initial_value=float(initial_value), initial_time=initial_time)
+    # Set all hyperparameters as explicit attributes, such that sklearn's CV utilities work
+    self.default_k = default_k
+    self.k = k_fn or (lambda _: default_k)
+
+  def evolve_rating(self, r1, r2, label):
+    exp = self.compute_prob(r1, r2)
+    return r1 + self.k(r1) * (label - exp)
+
+  @staticmethod
+  def compute_prob(r1, r2):
+    diff = (r2 - r1) / 400.0
+    prob = 1.0 / (1 + 10**diff)
+    return prob
+```
+
+  - Extend the `RatingEstimator` to wrap the new `RatingModel` subclass and specify the list of `RatingModel` attributes that should be considered hyperparamters when dynamically building a `RatingsModel` in the estimator's `fit` method
+
+```
+class EloEstimator(RatingEstimator):
+
+  RATING_MODEL_CLS = EloModel
+
+  RATING_MODEL_ATTRIBUTES = [
+    'default_k',
+    'k_fn',
+    'initial_value',
+    'initial_time',
+  ]
+
+  def __init__(self, key1_field=None, key2_field=None, timestamp_field=None, default_k=20, k_fn=None, initial_value=1500, initial_time=0, **kwargs):
+    super().__init__(
+      key1_field=key1_field,
+      key2_field=key2_field,
+      timestamp_field=timestamp_field,
+      initial_value=initial_value,
+      initial_time=initial_time,
+      **kwargs
+    )
+    # These must be set as estimator attributes
+    self.default_k = default_k
+    self.k_fn = k_fn
+```

--- a/README.md
+++ b/README.md
@@ -431,3 +431,6 @@ class EloEstimator(RatingEstimator):
     self.default_k = default_k
     self.k_fn = k_fn
 ```
+
+Please note that a `rating` can be anything, so long as it's convenient and can support the above call signatures to create a new rating object like-for-like from existing rating objects.
+For example, our `EloModel` implementation uses a plain `float`, and the `Glicko2Model` uses a 3-tuple for the 3 generative parameters for a player's rating.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ It's intended to provide a simple API for creating elo ratings in a small games 
 What problem does this package solve?
 
 Despite there being many ratings systems implementations available (e.g. [sublee/elo](https://github.com/sublee/elo/) [ddm7018/Elo](https://github.com/ddm7018/Elo), [rshk/elo](https://github.com/rshk/elo), [EloPy](https://github.com/HankSheehan/EloPy), [PythonSkills](https://github.com/McLeopold/PythonSkills), [pyglicko2](https://github.com/ryankirkman/pyglicko2), [glicko](https://github.com/sublee/glicko)) it's hard to find one that satisfies several criteria for ease of use:
-  - A simple and clean API that's convenient for a data-driven model development loop, for which use case the scikit-learn estimator [interface](https://scikit-learn.org/stable/modules/classes.html) is the *de facto* standard
+  - A simple and clean API that's convenient for a data-driven model development loop, for which use case the scikit-learn estimator [interface](https://scikit-learn.org/stable/modules/classes.html) is the *de facto* standard for this use case
   - Explicit management of intervals of validity for ratings, such that as matches occur a timeseries of ratings is evolved for each players (i.e. type-2 data management as opposed to type-1 fire-and-forget ratings)
+
+This package addresses the criteria above by providing a simple interface for storing the 
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
   "numpy",
   "sklearn",
   "pandas",
+  "pyglicko2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skelo"
-version = "0.0.4"
+version = "0.1.0"
 authors = [
   { name="Michael B Hynes", email="mike.hynes.rhymes@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ requires = [
   "numpy",
   "sklearn",
   "pandas",
-  "pyglicko2",
+  "glicko2",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "skelo"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Michael B Hynes", email="mike.hynes.rhymes@gmail.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 sklearn
 pandas
 pytest
+glicko2

--- a/skelo/model/__init__.py
+++ b/skelo/model/__init__.py
@@ -174,12 +174,12 @@ class RatingModel(object):
     r2 = self.get(loser)
     if timestamp < r1['valid_from']:
       raise ValueError(
-        f"Attempted to retrospectively update a rating for {winnder} at timestamp '{timestamp}' "
+        f"Attempted to retrospectively update a rating for {winner} at timestamp '{timestamp}' "
         f"which is earlier than the latest available rating at timestamp '{r1['valid_from']}'"
       )
     if timestamp < r2['valid_from']:
       raise ValueError(
-        f"Attempted to retrospectively update a rating for {winnder} at timestamp '{timestamp}' "
+        f"Attempted to retrospectively update a rating for {loser} at timestamp '{timestamp}' "
         f"which is earlier than the latest available rating at timestamp '{r2['valid_from']}'"
       )
     r1['valid_to'] = timestamp
@@ -360,7 +360,10 @@ class RatingEstimator(BaseEstimator, ClassifierMixin):
     Args:
       X (numpy.ndarray or pandas DataFrame): design matrix of matches with key1, key2, timestamp data
       y (numpy.ndarray or pandas DataFrame): vector of match outcomes, where 1 denotes player key1 won
-
+      incremental_fit (bool): if false, subsequent calls to fit refit the model and discard old ratings.
+        If True, else the model's ratings may be incrementally updated with (new) training data.
+        When fitting incrementally, ensure that all matches for any player are monotonically
+        increasing in time.
     Returns:
       EloEstimator: this object
     """

--- a/skelo/model/__init__.py
+++ b/skelo/model/__init__.py
@@ -1,0 +1,516 @@
+# Copyright (c) 2022 Michael B Hynes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import bisect
+import logging
+
+import numpy as np
+import pandas as pd
+
+from sklearn.base import BaseEstimator, ClassifierMixin
+
+logger = logging.getLogger(__name__)
+
+
+class RatingModel(object):
+  """
+  Base class specifying the API to update and store player ratings data.
+  """
+
+  def __init__(self, initial_value, initial_time):
+    self.initial_value = initial_value
+    self.initial_time = initial_time
+    self.ratings = {}
+
+  @property
+  def keys(self):
+    """
+    Returns:
+       dict_keys: the current keys (player identifiers) for all players in the system.
+    """
+    return self.ratings.keys()
+
+  def build(self, keys):
+    """
+    Lazily initialize the RatingModel by populating the ratings dictionary.
+
+    Args:
+      keys: iterable of player keys to use for identifying players in the system
+  
+    Returns:
+      RatingModel: this object
+    """
+    for key in keys:
+      self.add(key, value=self.initial_value)
+    return self
+
+  def add(self, key, value=None):
+    """
+    Add a single player to the rating system.
+    If the player already exists, no action is performed.
+
+    Args:
+      key: identifier for the player
+      value: initial value of the player's rating
+
+    Returns:
+      RatingModel: this object
+    """
+    if key in self.ratings:
+      return self
+    self.ratings[key] = [{
+      'rating': value or self.initial_value,
+      'valid_from': self.initial_time,
+      'valid_to': None,
+    }]
+    return self
+
+  def get(self, key, timestamp=None, strict_past_data=True):
+    """
+    Retrieve a player rating payload for the specified system timestamp.
+    The timestamp will be used to retrieve the dictionary of rating data
+    for the player as of the timestamp. If timestmap=None is passed, the
+    last appended rating record is returned.
+
+    If strict_past_data is True, then no ratings data from matches at times
+    equal to or greater than timestamp will be returned. This is useful to
+    ensure that no future information leaks into the retrieved ratings. 
+
+    If strict_past_data is False, then in the event that there exist 1 or more
+    matches at timestamp, the last appended rating for that timestamp will be
+    returned.
+
+    As an example, consider the following ratings for a player:
+    [
+      {'valid_from': 1, 'valid_to': 2,    'rating': 1500},
+      {'valid_from': 2, 'valid_to': 2,    'rating': 1510},
+      {'valid_from': 2, 'valid_to': 3,    'rating': 1520},
+      {'valid_from': 3, 'valid_to': None, 'rating': 1530},
+    ]
+    These ratings correspond to 3 matches played at times 2, 2, and 3. The first
+    rating is simply a book-keeping record that gives the initial rating value
+    at the system initial time. It is permissible to have 2 matches occur at the
+    same time (but not recommended since you cannot in general retrieve a
+    physically meaningful rating in the event of collisions in time).
+
+    In this example:
+      - the call get(key, 1) returns record 1 (rating 1500), regardless of the value
+        of strict_past_data, since this record should be returned for any timestamp
+        prior to the first observed match for the player
+      - the call get(key, 2, strict_past_data=True) returns record 1 (rating 1500)
+      - the call get(key, 2, strict_past_data=False) returns record 3 (rating 1520)
+      - the call get(key, 3, strict_past_data=True) returns record 3 (rating 1530)
+      - the call get(key, 4) returns record 4 (rating 1520)
+      - the call get(key) returns record 4 (rating 1520), since no timestamp is given
+
+    For use cases in which future data leakage is problematic (e.g. forecasting),
+    strict_past_data=True should always be used. For use cases where simple ratings
+    retrieval is desired and the match start time is a more convenient ledger timestamp,
+    strict_past_data=False is appropriate.
+
+    Args:
+      key: identifier for the player
+      timestamp: system time at which to retrieve the ratings data
+      strict_past_data (bool): if true, ensure no future data is returned if the
+        provided timestamp exactly matches a match timestamp
+        
+    Returns:
+      dict: ratings payload of the rating data for a player with keys:
+        ['rating', 'valid_from', 'valid_to']
+
+    Raises:
+      KeyError: if key is not yet added to the system
+    """
+    ratings = self.ratings.get(key)
+    if ratings is None:
+      raise KeyError(f"key: {key} is not yet stored in the model.")
+
+    if timestamp is None:
+      idx = -1
+    else:
+      start_ts = [r['valid_from'] for r in ratings]
+      bisect_fn = bisect.bisect_left if strict_past_data else bisect.bisect_right
+      idx_unbounded = bisect_fn(start_ts, timestamp) - 1
+      idx = min(len(ratings), max(0, idx_unbounded))
+    return ratings[idx]
+
+  def update(self, winner, loser, timestamp):
+    """
+    Update the ratings for the given players for a match at the provided timestamp
+    by performing the following operations:
+      - set the players' latest rating valid_to time to timestamp
+      - calculate the new ratings and append these with valid_from set to timestamp
+
+    Args:
+      winner: identifier for the player who won
+      loser: identifier for the player who lost
+      timestamp: system time at which the match occurred
+
+    Returns:
+      RatingModel: this object
+
+    Raises:
+      KeyError: if winner or loser is not yet added to the system
+      ValueError: if winner or loser is updated retroactively
+    """
+    r1 = self.get(winner)
+    r2 = self.get(loser)
+    if timestamp < r1['valid_from']:
+      raise ValueError(
+        f"Attempted to retrospectively update a rating for {winnder} at timestamp '{timestamp}' "
+        f"which is earlier than the latest available rating at timestamp '{r1['valid_from']}'"
+      )
+    if timestamp < r2['valid_from']:
+      raise ValueError(
+        f"Attempted to retrospectively update a rating for {winnder} at timestamp '{timestamp}' "
+        f"which is earlier than the latest available rating at timestamp '{r2['valid_from']}'"
+      )
+    r1['valid_to'] = timestamp
+    r2['valid_to'] = timestamp
+    self.ratings[winner].append({
+      'valid_from': timestamp,
+      'valid_to': None,
+      'rating': self.evolve_rating(r1['rating'], r2['rating'], label=1),
+    })
+    self.ratings[loser].append({
+      'valid_from': timestamp,
+      'valid_to': None,
+      'rating': self.evolve_rating(r2['rating'], r1['rating'], label=0),
+    })
+    return self
+
+  @staticmethod
+  def compute_prob(r1, r2):
+    """
+    Return the probability of a player with rating r1 beating a player with rating r2.
+    """
+    raise NotImplementedError
+
+  def predict_proba(self, key1, key2, timestamp=None, strict_past_data=True):
+    """
+    Compute the probability of victory of player key1 over player key2 at the
+    given timestamp. If no timestamp is provided, then the latest rating for
+    a player is used to calculate the probability.
+
+    Either scalar values or iterable values may be provided for key1, key2, and
+    timestamp to provide a convenient API bulk prediction (i.e. the caller need
+    not write a for-loop to call predict_proba multiple times).
+
+    Args:
+      key1: identifier for player 1, or iterable of identifiers
+      key2: identifier for player 2, or iterable of identifiers
+      timestamp: match time, or iterable of match times
+      strict_past_data (bool): if true, ensure no future data is returned if the
+        provided timestamp exactly matches a match timestamp
+
+    Returns:
+      float or list[float]: probability of player 1 beating player 2
+    """
+    is_scalar = type(key1) is str or not hasattr(key1, '__iter__')
+    if is_scalar:
+      key1 = [key1]
+      key2 = [key2]
+    else:
+      if len(key1) != len(key2):
+        raise ValueError(f"Iterables of keys must be the same length; received {len(key1)} vs {len(key2)}.")
+
+    if timestamp is None:
+      tuples = zip(key1, key2, len(key1) * [None])
+    else:
+      if is_scalar:
+        tuples = zip(key1, key2, [timestamp])
+      else:
+        if len(timestamp) != len(key1):
+          raise ValueError(f"Provided timestamps should be iterable with same length as keys ({len(key1)})")
+        tuples = zip(key1, key2, timestamp)
+
+    probs = []
+    for (p1, p2, ts) in tuples:
+      # Get the ratings for p1, p2 at the specified match time, `ts`.
+      r1 = self.get(p1, ts, strict_past_data=strict_past_data).get('rating', np.nan)
+      r2 = self.get(p2, ts, strict_past_data=strict_past_data).get('rating', np.nan)
+      pr = self.compute_prob(r1, r2)
+      probs.append(pr)
+    if is_scalar:
+      probs = probs[0]
+    return probs
+
+  def transform(self, key1, key2, timestamp=None, strict_past_data=True):
+    """
+    Transform the player key pairs into their respective ratings at the
+    given timestamp. If no timestamp is provided, then the latest ratings
+    are used.
+
+    Either scalar values or iterable values may be provided for key1, key2, and
+    timestamp to provide a convenient API bulk prediction (i.e. the caller need
+    not write a for-loop to call transform multiple times).
+
+    Args:
+      key1: identifier for player 1, or iterable of identifiers
+      key2: identifier for player 2, or iterable of identifiers
+      timestamp: match time, or iterable of match times
+      strict_past_data (bool): if true, ensure no future data is returned if the
+        provided timestamp exactly matches a match timestamp
+
+    Returns:
+      tuple[float] or list[tuple[float]]: ratings for the players or list thereof
+    """
+    is_scalar = type(key1) is str or not hasattr(key1, '__iter__')
+    if is_scalar:
+      key1 = [key1]
+      key2 = [key2]
+      timestamp = [timestamp]
+    ratings = []
+    for (p1, p2, ts) in zip(key1, key2, timestamp):
+      # Get the ratings for p1, p2 at the given match_at time
+      r1 = self.get(p1, ts, strict_past_data=strict_past_data).get('rating', np.nan)
+      r2 = self.get(p2, ts, strict_past_data=strict_past_data).get('rating', np.nan)
+      ratings.append((r1, r2))
+    if is_scalar:
+      ratings = ratings[0]
+    return ratings
+
+  def to_frame(self, keys=None):
+    """
+    Return the stored player ratings as a pandas DataFrame.
+    """
+    columns = ['key', 'rating', 'valid_from', 'valid_to']
+    keys = keys or self.ratings.keys()
+    dfs = []
+    for key in keys:
+      df = pd.DataFrame(self.ratings[key])
+      df['key'] = key
+      dfs.append(df)
+    if len(dfs) == 0:
+      return pd.DataFrame(columns=columns)
+    return pd.concat(dfs, axis=0, ignore_index=True)[columns]
+
+
+class RatingEstimator(BaseEstimator, ClassifierMixin):
+  """
+  A scikit-learn Classifier implementing a rating system.
+
+  This class creates an RatingModel ratings object and provides the scikit-learn API for using it:
+    - fit(X, y) to fit a model
+    - predict_proba(X) to generate continuous-valued predictions of match outcomes
+    - predict(X) to generate binary prediction labels for match outcomes
+    - transform(X) to map player tuples into their respective ratings
+  """
+
+  # Define the type of RatingModel. This should be overridden by child classes. 
+  RATING_MODEL_CLS = RatingModel
+
+  # Define a list of attributes of this object that should be passed as kwargs
+  # when instantiating a RatingModel during calls to fit(). This should be overridden
+  # by child classes.
+  RATING_MODEL_ATTRIBUTES = [
+    'initial_time',
+    'initial_value',
+  ]
+
+  def __init__(self, key1_field=None, key2_field=None, timestamp_field=None, initial_value=None, initial_time=0, **kwargs):
+    """
+    Construct a classifier object, without fitting it.
+    
+    Args:
+      key1_field (string): column name of the player1 key, if fit on a pandas DataFrame
+      key2_field (string): column name of the player2 key, if fit on a pandas DataFrame
+      timestamp_field (string): column name of the timestamp field, if fit on a pandas DataFrame
+      initial_value: initial rating value to assign a new player
+      initial_time: earliest possible time in the rating system (to be treated like -np.inf)
+      kwargs: kwargs to pass to the scikit-learn BaseEstimator
+    """
+    super().__init__(**kwargs)
+    self.initial_value = initial_value
+    self.initial_time = initial_time
+    self.rating_model = None
+
+    self.key1_field = key1_field
+    self.key2_field = key2_field
+    self.timestamp_field = timestamp_field
+    if any([key1_field, key2_field, timestamp_field]):
+      if not all([key1_field, key2_field, timestamp_field]):
+        raise ValueError(
+          f"All fields (key1_field, key2_field, timestamp_field) must be provided to fit using a DataFrame."
+        )
+    self._can_transform_dataframe = (key1_field is not None)
+    self._fit = False
+
+  def fit(self, X, y, incremental_fit=False):
+    """
+    Fit the classifier by computing the ratings for each player given the match data.
+
+    Args:
+      X (numpy.ndarray or pandas DataFrame): design matrix of matches with key1, key2, timestamp data
+      y (numpy.ndarray or pandas DataFrame): vector of match outcomes, where 1 denotes player key1 won
+
+    Returns:
+      EloEstimator: this object
+    """
+    if type(X) is pd.DataFrame:
+      if self._can_transform_dataframe:
+        x = X[[self.key1_field, self.key2_field, self.timestamp_field]].values
+      else:
+        logger.warning(
+          f"Attempting to transform a dataframe without attributes [key1_field, key2_field, timestamp_field]; using columns [0, 1, 2]"
+        )
+        x = X.iloc[:, :3].values
+    else:
+      x = X
+    if type(y) is pd.DataFrame:
+      y = y.iloc[:, 0].values
+    else:
+      y = y
+
+    min_time = np.min(x[:, -1])
+    time_dtype = type(min_time)
+    initial_time = None
+    attempt_init_times = [-np.inf, 0, min_time]
+    for val in attempt_init_times:
+      try:
+        initial_time = initial_time or time_dtype(val)
+      except Exception as e:
+        initial_time = None
+    if initial_time is None:
+      raise ValueError(
+        "Could not create an initial timestamp to use for ratings during fit. "
+        "Please verify the dtype of the column."
+      )
+
+    if not self._fit or not incremental_fit:
+      # Create a new underlying ratings model if fit() has not been called,
+      # or fit() is called with incremental_fit=False.
+      self.rating_model = self.RATING_MODEL_CLS(**{
+        attr: getattr(self, attr)
+        for attr in self.RATING_MODEL_ATTRIBUTES
+      })
+
+    # Update the keyset. If fit(..., incremental_fit=True) is called, this operation
+    # may add nonexistent keys but will not affect any existing data in the system.
+    keys = set(x[:, 0])
+    keys.update(set(x[:, 1]))
+    self.rating_model.build(keys)
+
+    # Add new match observations into the rating system
+    sort_key = lambda r: (r[0][-1], r[0][0], r[0][1])
+    for (_x, _y) in sorted(zip(x, y), key=sort_key):
+      winner = _x[0] if _y else _x[1]
+      loser = _x[1] if _y else _x[0]
+      timestamp = _x[-1]
+      self.rating_model.update(winner, loser, timestamp)
+
+    self._fit = True
+    return self
+
+  def transform(self, X, output_type='prob', strict_past_data=True):
+    """
+    Transform the player identifier matrix into either the player ratings or the estimated
+    probability of player 1 defeating player 2.
+
+    This method may be used after the model has been fit to convert a design matrix of
+    player identifiers into numerical quantities at either historical times or future times.
+    It should be preferred to predict_proba when historical as-of probabilities are desired
+    in which the match outcome is known but the player ratings (or victory probabilities
+    estimated thereby) immediately prior to the match are desired for model backtesting or
+    training use cases. The method predict_proba will only return probabilities for strict
+    future matches, and is not suitable for historical as-of predictions.
+
+    Args:
+      X (numpy.ndarray or pandas DataFrame): design matrix of matches with key1, key2, timestamp data
+      output_type (string): either 'prob' or 'rating' to specify the type of transformation
+      strict_past_data (bool): if true, ensure no future data is returned if the
+        provided timestamp exactly matches a match timestamp
+
+    Returns:
+      An ndarry or pandas Series of transformed ratings or probabilities.
+    """
+    allowed_output_types = ['prob', 'rating']
+    if output_type not in allowed_output_types:
+      raise ValueError(f"output_type must be one of: {allowed_output_types}")
+    if not self._fit:
+      raise ValueError(".fit() has not been called on this model.")
+
+    dtype = type(X)
+    if dtype is pd.DataFrame:
+      if self._can_transform_dataframe:
+        x = X[[self.key1_field, self.key2_field, self.timestamp_field]].values
+      else:
+        logger.warning(
+          f"Attempting to transform a dataframe without attributes [key1_field, key2_field, timestamp_field]; using columns [0, 1, 2]"
+        )
+        x = X.iloc[:, :3].values
+    else:
+      x = X
+    if output_type == 'prob':
+      transformed = np.array(
+        self.rating_model.predict_proba(x[:, 0], x[:, 1], x[:, 2], strict_past_data=strict_past_data)
+      )
+    else:
+      transformed = np.array(
+        self.rating_model.transform(x[:, 0], x[:, 1], x[:, 2], strict_past_data=strict_past_data)
+      )
+
+    if dtype is pd.DataFrame and output_type == 'prob':
+      return pd.Series(
+        index=X.index,
+        data=transformed,
+      )
+    if dtype is pd.DataFrame and output_type == 'rating':
+      return pd.DataFrame(
+        index=X.index,
+        columns=['r1', 'r2'],
+        data=transformed,
+      )
+    return transformed
+
+  def predict_proba(self, X):
+    """
+    Predict the probability of of player 1 defeating player 2 for player identifiers in 
+    the provided design matrix using strict past data for each prediction.
+
+    Args:
+      X (numpy.ndarray or pandas DataFrame): design matrix of matches with key1, key2, timestamp data
+
+    Returns:
+      An ndarry or pandas DataFrame of the probabilities of victory for player 1 and 2, respectively.
+    """
+    pr = self.transform(X, output_type='prob', strict_past_data=True)
+    pr_inv = 1 - pr
+    if type(pr) is pd.Series:
+      return pd.concat([pr.rename('pr1'), pr_inv.rename('pr2')], axis=1)
+    else:
+      return np.c_[pr, pr_inv]
+
+  def predict(self, X):
+    """
+    Create a binary prediction label for player 1 to defeat player 2 for the player 
+    identifiers in the provided design matrix in *future* matches, using *only* the
+    latest available rating for each player after the model has been fit.  
+
+    Args:
+      X (numpy.ndarray or pandas DataFrame): design matrix of matches with key1, key2, timestamp data
+
+    Returns:
+      An ndarry or DataFrame of predicted labels of victory for player 1.
+    """
+    labels = np.round(self.predict_proba(X))
+    if type(labels) is pd.DataFrame:
+      return labels.iloc[:, 0]
+    return labels[:, 0]

--- a/skelo/model/elo.py
+++ b/skelo/model/elo.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 class EloModel(RatingModel):
   """
-  Dictionary-based implementation of the `Elo rating system`<https://en.wikipedia.org/wiki/Elo_rating_system>_.
+  Dictionary-based implementation of the `Elo rating system <https://en.wikipedia.org/wiki/Elo_rating_system>`_.
 
   This class creates a dictionary of Elo ratings for each player inserted into the rating system, such
   that each match update will append new ratings for the respective match players, calculated according
@@ -73,7 +73,7 @@ class EloModel(RatingModel):
 
 class EloEstimator(RatingEstimator):
   """
-  A scikit-learn Classifier implementing the `Elo rating system`<https://en.wikipedia.org/wiki/Elo_rating_system>_.
+  A scikit-learn Classifier implementing the `Elo rating system <https://en.wikipedia.org/wiki/Elo_rating_system>`_.
   """
   RATING_MODEL_CLS = EloModel
   RATING_MODEL_ATTRIBUTES = [

--- a/skelo/model/glicko2.py
+++ b/skelo/model/glicko2.py
@@ -24,66 +24,77 @@ import logging
 
 import numpy as np
 import pandas as pd
+import glicko2
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 
 from skelo.model import RatingModel, RatingEstimator
 
+
 logger = logging.getLogger(__name__)
 
 
-class EloModel(RatingModel):
+class Glicko2Model(RatingModel):
   """
-  Dictionary-based implementation of the `Elo rating system`<https://en.wikipedia.org/wiki/Elo_rating_system>_.
+  Dictionary-based implementation of the `Glicko2 rating system`<https://en.wikipedia.org/wiki/Glicko_rating_system>_.
 
-  This class creates a dictionary of Elo ratings for each player inserted into the rating system, such
+  This class creates a dictionary of Glicko2 ratings for each player inserted into the rating system, such
   that each match update will append new ratings for the respective match players, calculated according
-  to the Elo update formula.
+  to the Glicko2 update formula.
 
-  This model may be used directly, but is primarily intended as a utility class for an EloEstimator.
+  This model may be used directly, but is primarily intended as a utility class for an Glicko2Estimator.
   """
 
-  def __init__(self, default_k=20, k_fn=None, initial_value=1500, initial_time=0, **kwargs):
+  def __init__(self, initial_value=(1500., 350., 0.06), initial_time=0, **kwargs):
     """
-    Construct an Elo RatingsModel.
+    Construct a Glicko2 RatingsModel.
 
     Args:
-      default_k (int): default value of `k` to use in the Elo update formula if no `k_fn` is provided
-      k_fn (callable): univariate function of a rating that returns a value of `k` for updates
-      initial_value (int): initial default rating value to assign to a new player in the system
+      initial_value (float, float, float): initial default rating and deviation assigned to a new player
       initial_time (int or orderable): the earliest "time" value for matches between players.
     """
-    super().__init__(initial_value=float(initial_value), initial_time=initial_time)
-    self.default_k = default_k
-    self.k = k_fn or (lambda _: default_k)
+    super().__init__(initial_value=initial_value, initial_time=initial_time)
 
   def evolve_rating(self, r1, r2, label):
-    exp = self.compute_prob(r1, r2)
-    return r1 + self.k(r1) * (label - exp)
+    rating = glicko2.Player(*r1)
+    rating.update_player([r2[0]], [r2[1]], [label])
+    updated = (rating.getRating(), rating.getRd(), rating.vol)
+    return updated
 
   @staticmethod
   def compute_prob(r1, r2):
     """
     Return the probability of a player with rating r1 beating a player with rating r2.
+
+    For more background, please see the `Glicko Paper`<http://glicko.net/glicko/glicko.pdf>_
     """
-    diff = (r2 - r1) / 400.0
-    prob = 1.0 / (1 + 10**diff)
+    r_diff = (r2[0] - r1[0]) / 400.0
+    root_square_std = np.sqrt(r1[1]**2 + r2[1]**2)
+    g = glicko2.Player(*r1)._g(r1[1])
+    arg = g * root_square_std * r_diff
+    prob = 1.0 / (1 + 10**arg)
     return prob
 
 
-class EloEstimator(RatingEstimator):
+class Glicko2Estimator(RatingEstimator):
   """
-  A scikit-learn Classifier implementing the `Elo rating system`<https://en.wikipedia.org/wiki/Elo_rating_system>_.
+  A scikit-learn Classifier for creating ratings according to the 
+  `Glicko2 rating system`<https://en.wikipedia.org/wiki/Glicko_rating_system>_.
   """
-  RATING_MODEL_CLS = EloModel
+  RATING_MODEL_CLS = Glicko2Model
   RATING_MODEL_ATTRIBUTES = [
-    'default_k',
-    'k_fn',
     'initial_value',
     'initial_time',
   ]
 
-  def __init__(self, key1_field=None, key2_field=None, timestamp_field=None, default_k=20, k_fn=None, initial_value=1500, initial_time=0, **kwargs):
+  def __init__(self,
+    key1_field=None,
+    key2_field=None,
+    timestamp_field=None,
+    initial_value=(1500., 350., 0.06),
+    initial_time=0,
+    **kwargs
+  ):
     """
     Construct a classifier object, without fitting it.
     
@@ -100,5 +111,3 @@ class EloEstimator(RatingEstimator):
       initial_time=initial_time,
       **kwargs
     )
-    self.default_k = default_k
-    self.k_fn = k_fn

--- a/skelo/model/glicko2.py
+++ b/skelo/model/glicko2.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 class Glicko2Model(RatingModel):
   """
-  Dictionary-based implementation of the `Glicko2 rating system`<https://en.wikipedia.org/wiki/Glicko_rating_system>_.
+  Dictionary-based implementation of the `Glicko2 rating system <https://en.wikipedia.org/wiki/Glicko_rating_system>`_.
 
   This class creates a dictionary of Glicko2 ratings for each player inserted into the rating system, such
   that each match update will append new ratings for the respective match players, calculated according
@@ -56,6 +56,12 @@ class Glicko2Model(RatingModel):
     super().__init__(initial_value=initial_value, initial_time=initial_time)
 
   def evolve_rating(self, r1, r2, label):
+    """
+    Update a Glicko rating based on the outcome of a match.
+    
+    This is based on the example in the glicko2 package's unit tests,
+    available `here <https://github.com/deepy/glicko2/blob/master/tests/tests.py>`_
+    """
     rating = glicko2.Player(*r1)
     rating.update_player([r2[0]], [r2[1]], [label])
     updated = (rating.getRating(), rating.getRd(), rating.vol)
@@ -66,7 +72,7 @@ class Glicko2Model(RatingModel):
     """
     Return the probability of a player with rating r1 beating a player with rating r2.
 
-    For more background, please see the `Glicko Paper`<http://glicko.net/glicko/glicko.pdf>_
+    For more background, please see the `Glicko Paper <http://glicko.net/glicko/glicko.pdf>`_
     """
     r_diff = (r2[0] - r1[0]) / 400.0
     root_square_std = np.sqrt(r1[1]**2 + r2[1]**2)
@@ -79,7 +85,7 @@ class Glicko2Model(RatingModel):
 class Glicko2Estimator(RatingEstimator):
   """
   A scikit-learn Classifier for creating ratings according to the 
-  `Glicko2 rating system`<https://en.wikipedia.org/wiki/Glicko_rating_system>_.
+  `Glicko2 rating system <https://en.wikipedia.org/wiki/Glicko_rating_system>`_.
   """
   RATING_MODEL_CLS = Glicko2Model
   RATING_MODEL_ATTRIBUTES = [

--- a/tests/skelo/model/test_elo.py
+++ b/tests/skelo/model/test_elo.py
@@ -132,8 +132,8 @@ class TestEloEstimator:
     y = games.values[:, -1] # outcome
     estimator = EloEstimator().fit(X, y)
     for p in range(num_players):
-      fit_rating = estimator.elo.get(p, timestamp=None)['rating']
-      assert np.abs(fit_rating - ratings[p]) < estimator.elo.default_k
+      fit_rating = estimator.rating_model.get(p, timestamp=None)['rating']
+      assert np.abs(fit_rating - ratings[p]) < estimator.rating_model.default_k
 
   def test_fit_dataframe(self):
     num_players = 4
@@ -141,8 +141,8 @@ class TestEloEstimator:
     games = pd.DataFrame(data_utils.generate_constant_game_outcomes(ratings, num_timesteps=100))
     estimator = EloEstimator('p1', 'p2', 'match_at').fit(games, games['label'])
     for p in range(num_players):
-      fit_rating = estimator.elo.get(p, timestamp=None)['rating']
-      assert np.abs(fit_rating - ratings[p]) < estimator.elo.default_k
+      fit_rating = estimator.rating_model.get(p, timestamp=None)['rating']
+      assert np.abs(fit_rating - ratings[p]) < estimator.rating_model.default_k
 
   def test_transform_dataframe(self):
     num_players = 2
@@ -152,15 +152,15 @@ class TestEloEstimator:
 
     transformed_ratings = estimator.transform(games, output_type='rating')
     for k, (_, g) in enumerate(games.iterrows()):
-      r1_expected = estimator.elo.get(g['p1'], timestamp=g['match_at'])['rating']
-      r2_expected = estimator.elo.get(g['p2'], timestamp=g['match_at'])['rating']
+      r1_expected = estimator.rating_model.get(g['p1'], timestamp=g['match_at'])['rating']
+      r2_expected = estimator.rating_model.get(g['p2'], timestamp=g['match_at'])['rating']
       assert r1_expected == transformed_ratings.iloc[k]['r1']
       assert r2_expected == transformed_ratings.iloc[k]['r2']
 
     transformed_prob = estimator.transform(games, output_type='prob')
     for k, (_, g) in enumerate(games.iterrows()):
-      r1_expected = estimator.elo.get(g['p1'], timestamp=g['match_at'])['rating']
-      r2_expected = estimator.elo.get(g['p2'], timestamp=g['match_at'])['rating']
+      r1_expected = estimator.rating_model.get(g['p1'], timestamp=g['match_at'])['rating']
+      r2_expected = estimator.rating_model.get(g['p2'], timestamp=g['match_at'])['rating']
       prob = EloModel.compute_prob(r1_expected, r2_expected)
       assert transformed_prob.iloc[k] == EloModel.compute_prob(r1_expected, r2_expected)
 
@@ -174,15 +174,15 @@ class TestEloEstimator:
 
     transformed_ratings = estimator.transform(X, output_type='rating')
     for k, (_, g) in enumerate(games.iterrows()):
-      r1_expected = estimator.elo.get(g['p1'], timestamp=g['match_at'])['rating']
-      r2_expected = estimator.elo.get(g['p2'], timestamp=g['match_at'])['rating']
+      r1_expected = estimator.rating_model.get(g['p1'], timestamp=g['match_at'])['rating']
+      r2_expected = estimator.rating_model.get(g['p2'], timestamp=g['match_at'])['rating']
       assert r1_expected == transformed_ratings[k, 0]
       assert r2_expected == transformed_ratings[k, 1]
 
     transformed_prob = estimator.transform(X, output_type='prob')
     for k, (_, g) in enumerate(games.iterrows()):
-      r1_expected = estimator.elo.get(g['p1'], timestamp=g['match_at'])['rating']
-      r2_expected = estimator.elo.get(g['p2'], timestamp=g['match_at'])['rating']
+      r1_expected = estimator.rating_model.get(g['p1'], timestamp=g['match_at'])['rating']
+      r2_expected = estimator.rating_model.get(g['p2'], timestamp=g['match_at'])['rating']
       prob = EloModel.compute_prob(r1_expected, r2_expected)
       assert transformed_prob[k] == prob
 


### PR DESCRIPTION
## Summary

- This PR creates a glicko2 estimator class
- To make this short & sweet, there is a refactor of the Elo class, essentially ripping out all the sklearn interface logic and putting those into parent classes
- The glicko class simply wraps the api from https://github.com/deepy/glicko2

## Other Implementations Considered

- Write your own / Copy exact code from others
   - Not worth the effort/time right now
- An alternate option was https://github.com/McLeopold/PythonSkills/blob/master/skills/glicko.py. 
   - I'd actually prefer this one since it also contains the Elo/trueskill/glicko1 all with approximately the same interface, and is a bit cleaner in code structure. However trueskill is patented anyway and would take some re-thinking of the interface here to implement, and this algo is glicko1 not glicko2


## Testing

- Shamefully I didn't write any unit tests for this, I just ran it on the exact same data as the example for the Elo and got only very slightly better results, which is what I'd expect based on the arXiv papers / blogs that compare the 2, e.g.: https://arxiv.org/pdf/1903.07746.pdf
- I checked this packages and uploads to the test pypi repo: (https://test.pypi.org/project/skelo/0.0.4/)
```
./dev package
./dev upload --test
```