### PR TITLE
Rename sklearn dependency to scikit-learn in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-sklearn
+scikit-learn
 pandas
 pytest
 glicko2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
   python_requires='>=3',
   install_requires=[
     "numpy",
-    "sklearn",
+    "scikit-learn",
     "pandas",
     "glicko2>=2",
   ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="skelo",
-  version="0.1.3",
+  version="0.1.4",
   author="Michael B Hynes",
   author_email="mike.hynes.rhymes@gmail.com",
   description="A scikit-learn interface to the Elo and Glicko2 rating systems",


### PR DESCRIPTION
## Summary

- `sklearn` is not the canonical name for the `scikit-learn` package
- This is causing installation errors for users due to the upstream brownout, see: https://pypi.org/project/sklearn/
![image](https://user-images.githubusercontent.com/10452129/205334896-f5b2f198-da13-467c-9499-e7d2d830635e.png)

## Issues

https://github.com/mbhynes/skelo/issues/6


## Testing

### Local Tests - pass

```bash
rm -r .venv
./dev up
./dev test
```
![image](https://user-images.githubusercontent.com/10452129/205334489-f6c875d2-33ae-4daf-97bf-c4d152754a05.png)

### Test Package Upload

```bash
./dev package
./dev upload --test
```
![image](https://user-images.githubusercontent.com/10452129/205335892-e44a97ea-8fc0-4d79-959c-f0ebac17bc0c.png)

View at: https://test.pypi.org/project/skelo/0.1.5/

Manual check on installation:
![image](https://user-images.githubusercontent.com/10452129/205336199-4dbb0bf8-6196-4b3a-a990-d1afb496c141.png)

