### PR TITLE
disallow caching in pip install

### DIFF
--- a/bin/dev-upload
+++ b/bin/dev-upload
@@ -31,6 +31,7 @@ if [[ "$repository" == "testpypi" ]]; then
   source "$v/bin/activate" || die "Failed to activate venv from: $v"
   log "\n\nInstalling $PACKAGE_NAME to virtualenv: $v"
   pip3 install \
+    --no-cache-dir \
     --index-url https://test.pypi.org/pypi/ \
     --extra-index-url https://pypi.org/simple \
     "$PACKAGE_NAME"


### PR DESCRIPTION
## Summary

- When testing installation from test-pypi, force refreshing all dependencies:
![image](https://user-images.githubusercontent.com/10452129/205340576-de15e3ea-6599-4b04-8ac9-9e8ff7cabef2.png)
